### PR TITLE
Fix refresh token role retrieval

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -95,7 +95,8 @@ export const refreshToken = async (req, res) => {
     if (tokens.length === 0)
       return res.status(403).json({ message: 'Refresh token inválido o revocado' });
 
-    const nuevoAccessToken = generarAccessToken({ id: decoded.id, rol: decoded.rol });
+    const [[usuario]] = await pool.query('SELECT rol FROM usuarios WHERE id = ?', [decoded.id]);
+    const nuevoAccessToken = generarAccessToken({ id: decoded.id, rol: usuario?.rol });
     res.json({ accessToken: nuevoAccessToken });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- query user role from DB when refreshing token so JWT contains correct role

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685341b94dfc832f8feb8fd45250f675